### PR TITLE
wip: Add wrapped_send and wrapped_recv functions

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -7,5 +7,13 @@ set(SOURCES
     user_login.c
 )
 
+set(CommonLibDir ${CMAKE_SOURCE_DIR}/../common)
+
+add_library(CommonLib OBJECT
+      ${CommonLibDir}/src/unix_utils.c)
+target_include_directories(CommonLib PRIVATE ${CommonLibDir}/inc)
+
 # create the executable
-add_executable(client ${SOURCES})
+add_executable(client ${SOURCES}
+    $<TARGET_OBJECTS:CommonLib>)
+target_include_directories(client PRIVATE ${CommonLibDir}/inc)

--- a/common/inc/unix_utils.h
+++ b/common/inc/unix_utils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <stdint.h>
+#include <unistd.h>
+
+ssize_t retry_send(int sock_fd, const void *buf, size_t len, int flags);
+ssize_t retry_recv(int sock_fd, void *buf, size_t len, int flags);

--- a/common/src/unix_utils.c
+++ b/common/src/unix_utils.c
@@ -1,0 +1,42 @@
+#include "unix_utils.h"
+#include <errno.h>
+#include <assert.h>
+#include <sys/socket.h>
+
+ssize_t retry_send(int sock_fd, const void *buf, size_t len, int flags) {
+    ssize_t sent_len = 0;
+    while (sent_len != (ssize_t)len) {
+        const void *send_buf = (void*)((uintptr_t)buf + sent_len);
+        ssize_t ret = send(sock_fd, send_buf, len - sent_len, flags);
+        if (ret > 0)
+            sent_len += ret;
+        else {
+            if ((ret == -1) && ((errno == EINTR) || (errno == EAGAIN)))
+                continue;
+            else {
+                sent_len = ret;
+                break;
+            }
+        }
+    }
+    return sent_len;
+}
+
+ssize_t retry_recv(int sock_fd, void *buf, size_t len, int flags) {
+    ssize_t received_len = 0;
+    while (received_len != (ssize_t)len) {
+        void *recv_buf = (void*)((uintptr_t)buf + received_len);
+        ssize_t ret = recv(sock_fd, recv_buf, len - received_len, flags);
+        if (ret > 0)
+            received_len += ret;
+        else {
+            if ((ret == -1) && ((errno == EINTR) || (errno == EAGAIN)))
+                continue;
+            else {
+                received_len = ret;
+                break;
+            }
+        }
+    }
+    return received_len;
+}

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -8,5 +8,14 @@ set(SOURCES
     syslog.c
 )
 
+set(CommonLibDir ${CMAKE_SOURCE_DIR}/../common)
+
+add_library(CommonLib OBJECT
+      ${CommonLibDir}/src/unix_utils.c)
+target_include_directories(CommonLib PRIVATE ${CommonLibDir}/inc)
+
 # create the executable
-add_executable(server ${SOURCES})
+add_executable(server ${SOURCES}
+    $<TARGET_OBJECTS:CommonLib>)
+target_link_libraries(${PROJECT_NAME} PRIVATE pthread)
+target_include_directories(server PRIVATE ${CommonLibDir}/inc)


### PR DESCRIPTION
This pull request adds two utility functions, `wrapped_send` and `wrapped_recv`, to enhance the functionality of sending and receiving data over sockets. These functions handle partial sends and receives, as well as retries in case of interruptions.